### PR TITLE
After much discussion, disable this cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,6 +68,9 @@ Style/IndentationConsistency:
 Style/RegexpLiteral:
   Enabled: false
 
+Style/ParenthesesAroundCondition
+  Enabled: false
+
 # Use %w or %W for arrays of words.
 Style/WordArray:
   Enabled: false


### PR DESCRIPTION
It has a lot of issues with recommending removal of parantheses in cases where a conditional happens after a statement and the proper interpretation of precedence is non-trivial or unintuitive